### PR TITLE
Better error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 Generate Protobuf messages from given go structs. No RPC, not gogo syntax, just pure Protobuf messages.
 
+### Syntax
+```
+-f string
+    Protobuf output file path. (default ".")
+-filter string
+    Filter by type names.
+-p value
+    Fully qualified path of packages to analyse. Relative paths ("./example/in") are allowed.
+```
+
 ### Example
 
 ```sh
 GO111MODULE=off go get -u github.com/anjmao/go2proto
 go2proto -f ${PWD}/example/out -p github.com/anjmao/go2proto/example/in
 ```
+
+You can omit the -f path to default to
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@ Generate Protobuf messages from given go structs. No RPC, not gogo syntax, just 
 -f string
     Protobuf output file path. (default ".")
 -filter string
-    Filter by type names.
+    Filter by struct names. Case insensitive.
 -p value
     Fully qualified path of packages to analyse. Relative paths ("./example/in") are allowed.
 ```
 
 ### Example
 
+Your working directory must be inside of the package you wish to export. Package paths can be fully-qualified or relative.
+
 ```sh
 GO111MODULE=off go get -u github.com/anjmao/go2proto
-go2proto -f ${PWD}/example/out -p github.com/anjmao/go2proto/example/in
+cd ~/go/src/github.com/anjmao/go2proto
+go2proto -f ./example/out -p ./example/in
 ```
-
-You can omit the -f path to default to
 
 ### Note
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Generate Protobuf messages from given go structs. No RPC, not gogo syntax, just 
 
 ### Example
 
-Your working directory must be inside of the package you wish to export. Package paths can be fully-qualified or relative.
+Your package you wish to export must be inside of your working directory. Package paths can be fully-qualified or relative.
 
 ```sh
 GO111MODULE=off go get -u github.com/anjmao/go2proto

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func (i *arrFlags) Set(value string) error {
 }
 
 var (
-	filter       = flag.String("filter", "", "Filter by type names.")
+	filter       = flag.String("filter", "", "Filter by struct names. Case insensitive.")
 	targetFolder = flag.String("f", ".", "Protobuf output file path.")
 	pkgFlags     arrFlags
 )
@@ -60,7 +60,7 @@ func main() {
 		log.Fatalf("error fetching packages: %s", err)
 	}
 
-	msgs := getMessages(pkgs, *filter)
+	msgs := getMessages(pkgs, strings.ToLower(*filter))
 
 	if err := writeOutput(msgs, *targetFolder); err != nil {
 		log.Fatal(err)
@@ -124,7 +124,7 @@ func getMessages(pkgs []*packages.Package, filter string) []*message {
 			}
 			if s, ok := t.Type().Underlying().(*types.Struct); ok {
 				seen[t.Name()] = struct{}{}
-				if filter == "" || strings.Contains(t.Name(), filter) {
+				if filter == "" || strings.Contains(strings.ToLower(t.Name()), filter) {
 					out = appendMessage(out, t, s)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -37,17 +37,23 @@ func main() {
 	flag.Var(&pkgFlags, "p", "Go source packages.")
 	flag.Parse()
 
-	if len(pkgFlags) == 0 || protoFolder == nil {
+	pwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("error getting working directory: %s", err)
+	}
+
+	if len(pkgFlags) == 0 {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	if err := checkOutFolder(*protoFolder); err != nil {
-		log.Fatal(err)
+	if *protoFolder == "" {
+		outDir := "."
+		protoFolder = &outDir
+		log.Println("output flag -f not set, defaulting to working directory")
 	}
 
-	pwd, err := os.Getwd()
-	if err != nil {
+	if err := checkOutFolder(*protoFolder); err != nil {
 		log.Fatal(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,13 +30,13 @@ func (i *arrFlags) Set(value string) error {
 }
 
 var (
-	filter       = flag.String("filter", "", "Filter struct names.")
-	targetFolder = flag.String("f", "", "Proto output path.")
+	filter       = flag.String("filter", "", "Filter by type names.")
+	targetFolder = flag.String("f", ".", "Protobuf output file path.")
 	pkgFlags     arrFlags
 )
 
 func main() {
-	flag.Var(&pkgFlags, "p", "Go source packages.")
+	flag.Var(&pkgFlags, "p", `Fully qualified path of packages to analyse. Relative paths ("./example/in") are allowed.`)
 	flag.Parse()
 
 	pwd, err := os.Getwd()
@@ -47,13 +47,6 @@ func main() {
 	if len(pkgFlags) == 0 {
 		flag.PrintDefaults()
 		os.Exit(1)
-	}
-
-	//if output isnt set, set it to wd
-	if *targetFolder == "" {
-		outDir := "."
-		targetFolder = &outDir
-		log.Println("output flag -f not set, defaulting to working directory")
 	}
 
 	//ensure the path exists

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 
 type arrFlags []string
 
+const outputFileName = "output.proto"
+
 func (i *arrFlags) String() string {
 	return ""
 }
@@ -62,9 +64,11 @@ func main() {
 
 	msgs := getMessages(pkgs, strings.ToLower(*filter))
 
-	if err := writeOutput(msgs, *targetFolder); err != nil {
-		log.Fatal(err)
+	if err = writeOutput(msgs, *targetFolder); err != nil {
+		log.Fatalf("error writing output: %s", err)
 	}
+
+	log.Printf("output file written to %s%s%s\n", pwd, string(os.PathSeparator), outputFileName)
 }
 
 // attempt to load all packages
@@ -232,9 +236,9 @@ message {{.Name}} {
 		panic(err)
 	}
 
-	f, err := os.Create(filepath.Join(path, "output.proto"))
+	f, err := os.Create(filepath.Join(path, outputFileName))
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create file %s : %s", outputFileName, err)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
Primarily, this PR will output better error reporting when a package cant be loaded, rather than output a blank *.proto file. The package.Load() error did not contain any useful information about failed package loads, they must be fetched at a lower level. Additionally added some more documentation, hopefully to make it easier for new users to use this.